### PR TITLE
Bug fix : When several OU are found, OUned.py could not select which OU the user is targeting.

### DIFF
--- a/OUned.py
+++ b/OUned.py
@@ -458,9 +458,15 @@ def main(
         targetEntry = input(f"{bcolors.OKBLUE}[+] Select which OU you want to target : {bcolors.ENDC}")
         try: 
             targetEntry = int(targetEntry)
-            
+            if(targetEntry > ldap_entries):
+                logger.critical(f"{bcolors.FAIL}[!] This OU does not exist.{bcolors.ENDC}")
+                clean(ldap_session, ldap_server_session, save_file_name)
+                sys.exit(1)
+
         except:
             logger.critical(f"{bcolors.FAIL}[!] Failed to parse as integer.{bcolors.ENDC}")
+            clean(ldap_session, ldap_server_session, save_file_name)
+            sys.exit(1)
         
         ou_dn = ldap_session.entries[targetEntry-1].entry_dn
         logger.warning(f"{bcolors.OKGREEN}[+] The OU has been successfully targeted. - {ou_dn}.{bcolors.ENDC}") 

--- a/OUned.py
+++ b/OUned.py
@@ -445,9 +445,26 @@ def main(
     search_filter = f'(ou={ou})'
     attributes = [ALL_ATTRIBUTES]
     ldap_session.search(domain_dn, search_filter, SUBTREE, attributes=attributes)
-    if len(ldap_session.entries) == 1:
+    ldap_entries = len(ldap_session.entries)
+    if ldap_entries == 1:
         ou_dn = ldap_session.entries[0].entry_dn
         logger.warning(f"{bcolors.OKGREEN}[+] Organizational unit found - {ou_dn}.{bcolors.ENDC}")
+    elif ldap_entries >= 2:
+        logger.warning(f"{bcolors.OKBLUE}[+] Several OUs matching this name have been found.{bcolors.ENDC}")
+        numEntry = 0
+        for entry in ldap_session.entries:
+            logger.warning(f"{bcolors.OKBLUE}[+] {numEntry+1} :  {entry.entry_dn}.{bcolors.ENDC}")
+            numEntry+=1
+        targetEntry = input(f"{bcolors.OKBLUE}[+] Select which OU you want to target : {bcolors.ENDC}")
+        try: 
+            targetEntry = int(targetEntry)
+            
+        except:
+            logger.critical(f"{bcolors.FAIL}[!] Failed to parse as integer.{bcolors.ENDC}")
+        
+        ou_dn = ldap_session.entries[targetEntry-1].entry_dn
+        logger.warning(f"{bcolors.OKGREEN}[+] The OU has been successfully targeted. - {ou_dn}.{bcolors.ENDC}") 
+
     else:
         logger.error(f"{bcolors.FAIL}[!] Could not find Organizational Unit with name {ou}.{bcolors.ENDC}")
         clean(ldap_session, ldap_server_session, save_file_name)


### PR DESCRIPTION
**French : ( EN below )** 

Merci beaucoup pour ce super outil ! 
Je propose cette PR pour un cas de figure rencontré lors d'un pentest interne chez un client. 
Lorsque on essaye d'exploiter un WriteGPLink sur une OU, et que le nom de l'OU existe plusieurs fois dans le schéma, le script ne nous offre pas la possibilité de choisir quel DN précis est ciblé.

Pour l'instant, ma modification affiche les possibilités, propose à l'utilisateur de choisir, puis continue l'exécution du script normalement.

**Quelques screenshots** : 

- Cas de figure avec deux OU ayant le même nom :
![OUned_without_edit_2_OU](https://github.com/user-attachments/assets/1a9a9a9f-1e77-48b5-a88f-75b013809d38)
Nombre d'objets dans ldap_session.entries : 
![Debug_print_len_ldap_entries](https://github.com/user-attachments/assets/d0579486-b3c3-4d67-bb88-2e0bb7637f3e)


- Après bug fix : 
![OUned_with_ou_selection](https://github.com/user-attachments/assets/04e23253-4ff2-4354-b198-ca37b069a35d)


Voilà tout !
En-tout-cas super boulot pour l'outil, l'exploitation est extrêmement bien documentée sur votre article.



=================================================
=================================================


**English :** 

Thank you very much for this great tool! 
I suggest this PR for a scenario encountered during an internal pentest at a customer. 
When we try to exploit a WriteGPLink on an OU, and the name exists several times in the schema, the script doesn't give us the option of choosing which specific DN to target.

For the moment, my modification displays the possibilities, asks the user to choose, then continues to run the script as normal.

**A few screenshots** : 

- Case study with two OUs with the same name:
![OUned_without_edit_2_OU](https://github.com/user-attachments/assets/1a9a9a9f-1e77-48b5-a88f-75b013809d38)
Number of objects in ldap_session.entries : 
![Debug_print_len_ldap_entries](https://github.com/user-attachments/assets/d0579486-b3c3-4d67-bb88-2e0bb7637f3e)


- After bug fix : 
![OUned_with_ou_selection](https://github.com/user-attachments/assets/04e23253-4ff2-4354-b198-ca37b069a35d)


That's it!
Great job for the tool, the exploit is extremely well documented in your article.


